### PR TITLE
[codex] remove voice transcription feature flag

### DIFF
--- a/codex/config.toml
+++ b/codex/config.toml
@@ -27,5 +27,3 @@ ASDF_NODEJS_VERSION = "22.16.0"
 [features]
 # stable
 multi_agent = true
-# under development
-voice_transcription = true


### PR DESCRIPTION
## Summary
- remove the `voice_transcription` feature flag from `codex/config.toml`
- keep only the stable `multi_agent` feature enabled in the local Codex config

## Why
The `voice_transcription` flag is marked as under development and should no longer be enabled in this repository's shared config.

## Validation
- no automated checks were run
- verified the config diff locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **変更内容**
  * ボイス文字起こし機能がデフォルト設定から無効化されました。この機能を使用するにはマニュアル設定が必要になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->