### PR TITLE
chore: Claude/Codex のプラグイン設定と NO_FLICKER の追加

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_NO_FLICKER": "1"
+  },
   "model": "sonnet",
   "hooks": {
     "Notification": [
@@ -16,6 +19,12 @@
   "statusLine": {
     "type": "command",
     "command": "$HOME/.claude/statusline-powerline.sh"
+  },
+  "enabledPlugins": {
+    "notion@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "chrome-devtools-mcp@claude-plugins-official": false,
+    "sentry@claude-plugins-official": true
   },
   "language": "Japanese",
   "voiceEnabled": true

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -27,3 +27,12 @@ ASDF_NODEJS_VERSION = "22.16.0"
 [features]
 # stable
 multi_agent = true
+
+[plugins."google-calendar@openai-curated"]
+enabled = true
+
+[plugins."github@openai-curated"]
+enabled = true
+
+[plugins."notion@openai-curated"]
+enabled = true


### PR DESCRIPTION
## 概要

Claude Code と Codex のエージェント向け設定を更新します。

## 変更内容

### `claude/settings.json`
- `CLAUDE_CODE_NO_FLICKER` 環境変数を追加し、画面のフリッカーを抑制
- Notion / Context7 / Sentry プラグインを有効化（Chrome DevTools MCP は無効のまま）

### `codex/config.toml`
- Google Calendar / GitHub / Notion プラグイン（openai-curated）を有効化

## 確認

- [ ] ローカルで Claude Code / Codex を起動し、意図したプラグインが読み込まれること


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Google Calendar、GitHub、Notion などの主要サービスとの統合機能を追加しました
  * 複数のプラグインを有効化し、外部ツールとの連携オプションを拡張しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->