### PR TITLE
chore: Claude設定の権限・テーマ追加とCodexモデルバージョンアップ

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -27,5 +27,21 @@
     "sentry@claude-plugins-official": true
   },
   "language": "Japanese",
-  "voiceEnabled": true
+  "effortLevel": "high",
+  "theme": "auto",
+  "voiceEnabled": true,
+  "permissions": {
+    "deny": [
+      "Bash(rm*)"
+    ],
+    "allow": [
+      "Bash(git add*)",
+      "Bash(git pull*)",
+      "Bash(git commit*)",
+      "Bash(gh pr view*)",
+      "Bash(cmux read-screen *)",
+      "Bash(cmux capture-pane *)",
+      "Bash(asdf list *)"
+    ]
+  }
 }

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -1,7 +1,7 @@
 # モデル
-model = "gpt-5.4"
+model = "gpt-5.5"
 # デフォルト
-model_reasoning_effort = "high"
+model_reasoning_effort = "medium"
 # planモード
 plan_mode_reasoning_effort = "high"
 


### PR DESCRIPTION
## Summary
- `claude/settings.json`: `effortLevel: "high"`、`theme: "auto"` を追加。`rm*` を deny、git/gh/cmux/asdf コマンドを allow に追加
- `codex/config.toml`: モデルを `gpt-5.4` → `gpt-5.5` に更新、`model_reasoning_effort` を `high` → `medium` に変更

## Test plan
- [ ] Claude Code で設定が正しく反映されることを確認
- [ ] Codex で新しいモデル `gpt-5.5` が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * テーマ設定オプションが追加されました
  * コマンド権限制御機能が導入されました

* **設定変更**
  * デフォルトAIモデルが更新されました
  * AIの推論努力レベルが調整されました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XxGodmoonxX/my-ai-agent-code-settings/pull/28)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->