### PR TITLE
chore: Claude設定のeffortLevel変更とadvisorModel追加

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -2,6 +2,20 @@
   "env": {
     "CLAUDE_CODE_NO_FLICKER": "1"
   },
+  "permissions": {
+    "allow": [
+      "Bash(git add*)",
+      "Bash(git pull*)",
+      "Bash(git commit*)",
+      "Bash(gh pr view*)",
+      "Bash(cmux read-screen *)",
+      "Bash(cmux capture-pane *)",
+      "Bash(asdf list *)"
+    ],
+    "deny": [
+      "Bash(rm*)"
+    ]
+  },
   "model": "sonnet",
   "hooks": {
     "Notification": [
@@ -27,21 +41,8 @@
     "sentry@claude-plugins-official": true
   },
   "language": "Japanese",
-  "effortLevel": "high",
+  "effortLevel": "medium",
+  "advisorModel": "opus",
   "theme": "auto",
-  "voiceEnabled": true,
-  "permissions": {
-    "deny": [
-      "Bash(rm*)"
-    ],
-    "allow": [
-      "Bash(git add*)",
-      "Bash(git pull*)",
-      "Bash(git commit*)",
-      "Bash(gh pr view*)",
-      "Bash(cmux read-screen *)",
-      "Bash(cmux capture-pane *)",
-      "Bash(asdf list *)"
-    ]
-  }
+  "voiceEnabled": true
 }


### PR DESCRIPTION
## Summary
- `effortLevel` を `high` → `medium` に変更
- `advisorModel` に `opus` を設定
- `permissions` ブロックをファイル上部に移動（整理のみ、内容変更なし）

## Test plan
- [ ] Claude Codeで設定が正しく反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * AI処理の負荷レベルを「高」から「中」に変更しました。
  * アドバイザーモデルの設定を追加し、デフォルト値を「opus」に設定しました。
  * 権限設定の構成を最適化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XxGodmoonxX/my-ai-agent-code-settings/pull/30)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->