### PR TITLE
chore: Claude設定にgh pr diff権限・Notion MCP権限・skipAutoPermissionPrompt追加

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -8,12 +8,15 @@
       "Bash(git pull*)",
       "Bash(git commit*)",
       "Bash(gh pr view*)",
+      "Bash(gh pr diff*)",
       "Bash(cmux read-screen *)",
       "Bash(cmux capture-pane *)",
       "Bash(asdf list *)",
       "WebSearch",
       "Bash(cursor --version)",
-      "Bash(agent --help)"
+      "Bash(agent --help)",
+      "mcp__plugin_Notion_notion__notion-fetch",
+      "mcp__plugin_Notion_notion__notion-query-data-sources"
     ],
     "deny": [
       "Bash(rm*)"
@@ -49,5 +52,6 @@
   "effortLevel": "medium",
   "advisorModel": "opus",
   "theme": "auto",
-  "voiceEnabled": true
+  "voiceEnabled": true,
+  "skipAutoPermissionPrompt": true
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -16,7 +16,8 @@
       "Bash(cursor --version)",
       "Bash(agent --help)",
       "mcp__plugin_Notion_notion__notion-fetch",
-      "mcp__plugin_Notion_notion__notion-query-data-sources"
+      "mcp__plugin_Notion_notion__notion-query-data-sources",
+      "Skill(git-commit)"
     ],
     "deny": [
       "Bash(rm*)"


### PR DESCRIPTION
## Summary
- `Bash(gh pr diff*)` を allow 権限に追加
- Notion MCP の `notion-fetch` と `notion-query-data-sources` を allow 権限に追加
- `skipAutoPermissionPrompt: true` を追加（権限プロンプトの自動スキップ）

## Test plan
- [ ] Claude Code 起動後、対象のコマンド・MCP ツールが許可プロンプトなしで実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **権限設定の拡張** - GitHub コマンド、各種ユーティリティコマンド、WebSearch、Notion MCP プラグインが新たに許可されました。
* **権限プロンプトスキップ設定** - 自動の権限プロンプトをスキップする新しい設定オプションが追加されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XxGodmoonxX/my-ai-agent-code-settings/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->