### PR TITLE
chore: settings.jsonにglab・playwrightプラグインを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(rm*)"
+    ],
+    "allow": [
+      "Bash(git add*)",
+      "Bash(git pull*)",
+      "Bash(git checkout*)",
+      "Bash(git commit*)",
+      "Bash(git push*)",
+      "Bash(gh pr create*)",
+      "Bash(gh pr edit*)",
+      "Bash(gh pr merge*)",
+      "Bash(gh pr view*)",
+      "Skill(git-commit)"
+    ]
+  }
+}

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -17,7 +17,8 @@
       "Bash(agent --help)",
       "mcp__plugin_Notion_notion__notion-fetch",
       "mcp__plugin_Notion_notion__notion-query-data-sources",
-      "Skill(git-commit)"
+      "Skill(git-commit)",
+      "Bash(glab mr view*)"
     ],
     "deny": [
       "Bash(rm*)"
@@ -45,14 +46,14 @@
   "enabledPlugins": {
     "notion@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
-    "chrome-devtools-mcp@claude-plugins-official": false,
     "sentry@claude-plugins-official": true,
-    "github@claude-plugins-official": true
+    "github@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true
   },
   "language": "Japanese",
   "effortLevel": "medium",
   "advisorModel": "opus",
   "theme": "auto",
-  "voiceEnabled": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "voiceEnabled": true
 }


### PR DESCRIPTION
## Summary

- `Bash(glab mr view*)` をallow権限に追加
- `playwright@claude-plugins-official` プラグインを有効化
- `chrome-devtools-mcp@claude-plugins-official` を削除
- `voiceEnabled` と `skipAutoPermissionPrompt` のプロパティ順を整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)