### PR TITLE
chore: statusline-powerline.sh を実使用中の最新版に更新

### DIFF
--- a/claude/statusline-powerline.sh
+++ b/claude/statusline-powerline.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 # Powerline-style status line for Claude Code
-# Reads JSON input from stdin and creates a two-row status display
+# Reads JSON input from stdin and creates a three-row status display
+# Row 1: Model | Context | Version
+# Row 2: Git branch (+ stats)
+# Row 3: cwd
 
 # Read JSON input
 input=$(cat)
@@ -13,51 +16,74 @@ version=$(echo "$input" | jq -r '.version // ""')
 ctx_used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
 total_input=$(echo "$input" | jq -r '.context_window.total_input_tokens // 0')
 total_output=$(echo "$input" | jq -r '.context_window.total_output_tokens // 0')
+ctx_max=$(echo "$input" | jq -r '.context_window.context_window_size // 200000')
+effort=$(echo "$input" | jq -r '.effort.level // empty')
+added_dirs=()
+while IFS= read -r line; do
+    [ -n "$line" ] && added_dirs+=("$line")
+done < <(echo "$input" | jq -r '.workspace.added_dirs // [] | .[]')
 
 # Powerline separators (UTF-8 bytes for U+E0B0 and U+E0B2)
 SEP_RIGHT=$'\xEE\x82\xB0'  # Right-pointing separator
 SEP_LEFT=$'\xEE\x82\xB2'   # Left-pointing separator
 
 # Color definitions (using ANSI 256-color)
-PURPLE_BG="\033[48;5;135m"
-PURPLE_FG="\033[38;5;135m"
+PURPLE_BG="\033[48;5;141m"
+PURPLE_FG="\033[38;5;141m"
 YELLOW_BG="\033[48;5;221m"
 YELLOW_FG="\033[38;5;221m"
 GREEN_BG="\033[48;5;114m"
 GREEN_FG="\033[38;5;114m"
 PINK_BG="\033[48;5;218m"
 PINK_FG="\033[38;5;218m"
+CYAN_BG="\033[48;5;117m"
+CYAN_FG="\033[38;5;117m"
+ORANGE_BG="\033[48;5;209m"
+ORANGE_FG="\033[38;5;209m"
 WHITE_FG="\033[38;5;231m"
 BLACK_FG="\033[38;5;16m"
 BLACK_BG="\033[48;5;16m"
 RESET="\033[0m"
 
-# === Row 1: Model | Context | Git Branch | Git Stats | Version ===
+# === Row 1: Model | Context | Version ===
 row1=""
 
 # Model segment (purple bg, white text)
-row1+="${PURPLE_BG}${BLACK_FG} Model: ${model} ${RESET}"
+if [ -n "$effort" ]; then
+    row1+="${PURPLE_BG}${BLACK_FG} Model: ${model} [${effort}] ${RESET}"
+else
+    row1+="${PURPLE_BG}${BLACK_FG} Model: ${model} ${RESET}"
+fi
 row1+="${PURPLE_FG}${YELLOW_BG}${SEP_RIGHT}${RESET}"
 
 # Context segment (yellow bg, dark text)
 if [ -n "$ctx_used" ]; then
     total_k=$(awk "BEGIN {printf \"%.1fk\", ($total_input + $total_output) / 1000}")
-    row1+="${YELLOW_BG}${BLACK_FG} Ctx: ${total_k} ${RESET}"
+    max_k=$(awk "BEGIN {printf \"%.0fk\", $ctx_max / 1000}")
+    pct=$(awk "BEGIN {printf \"%.0f\", $ctx_used}")
+    row1+="${YELLOW_BG}${BLACK_FG} Ctx: ${total_k}/${max_k} (${pct}%) ${RESET}"
 else
     row1+="${YELLOW_BG}${BLACK_FG} Ctx: 0k ${RESET}"
 fi
 
-# Git info segment (green bg, dark text)
-if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
-    row1+="${YELLOW_FG}${GREEN_BG}${SEP_RIGHT}${RESET}"
+row1+="${YELLOW_FG}${PINK_BG}${SEP_RIGHT}${RESET}"
 
+# Version segment (pink bg, dark text)
+if [ -n "$version" ]; then
+    row1+="${PINK_BG}${BLACK_FG} v${version} ${RESET}"
+fi
+
+# === Row 2: Git Branch | Git Stats ===
+row2=""
+
+if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
     branch=$(git -C "$cwd" --no-optional-locks branch --show-current 2>/dev/null)
     if [ -z "$branch" ]; then
         branch=$(git -C "$cwd" --no-optional-locks rev-parse --short HEAD 2>/dev/null)
         branch="(detached:$branch)"
     fi
 
-    row1+="${GREEN_BG}${BLACK_FG} branch: ${branch} ${RESET}"
+    row2+="${GREEN_BG}${BLACK_FG} branch: ${branch} ${RESET}"
 
     # Git stats (additions/deletions)
     git_stats=$(git -C "$cwd" --no-optional-locks diff --shortstat 2>/dev/null)
@@ -66,21 +92,12 @@ if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
         deletions=$(echo "$git_stats" | grep -o '[0-9]* deletion' | grep -o '[0-9]*')
         [ -z "$additions" ] && additions="0"
         [ -z "$deletions" ] && deletions="0"
-        row1+="${GREEN_BG}${BLACK_FG} (+${additions},-${deletions}) ${RESET}"
+        row2+="${GREEN_BG}${BLACK_FG} (+${additions},-${deletions}) ${RESET}"
     fi
-
-    row1+="${GREEN_FG}${PINK_BG}${SEP_RIGHT}${RESET}"
-else
-    row1+="${YELLOW_FG}${PINK_BG}${SEP_RIGHT}${RESET}"
 fi
 
-# Version segment (pink bg, dark text)
-if [ -n "$version" ]; then
-    row1+="${PINK_BG}${BLACK_FG} v${version} ${RESET}"
-fi
-
-# === Row 2: CWD ===
-row2=""
+# === Row 3: CWD ===
+row3=""
 
 # Shorten cwd for display
 short_cwd="${cwd/#$HOME/~}"
@@ -93,7 +110,27 @@ if [ ${#short_cwd} -gt 40 ]; then
     fi
 fi
 
-row2+="${PURPLE_BG}${BLACK_FG} cwd: ${short_cwd} ${RESET}"
+row3+="${CYAN_BG}${BLACK_FG} cwd: ${short_cwd} ${RESET}"
 
-# Output both rows
-printf "%b\n%b\n" "$row1" "$row2"
+# === Row 4: Added directories (from --add-dir / /add-dir) ===
+row4=""
+
+if [ ${#added_dirs[@]} -gt 0 ]; then
+    dirs_display=""
+    for d in "${added_dirs[@]}"; do
+        short_d="${d/#$HOME/~}"
+        if [ -n "$dirs_display" ]; then
+            dirs_display+=", ${short_d}"
+        else
+            dirs_display="${short_d}"
+        fi
+    done
+    row4+="${ORANGE_BG}${BLACK_FG} add-dir: ${dirs_display} ${RESET}"
+fi
+
+# Output rows (row4 only when there are added directories)
+if [ -n "$row4" ]; then
+    printf "%b\n%b\n%b\n%b\n" "$row1" "$row2" "$row3" "$row4"
+else
+    printf "%b\n%b\n%b\n" "$row1" "$row2" "$row3"
+fi


### PR DESCRIPTION
## Summary
- `~/.claude/statusline-powerline.sh`（実際に運用中のファイル）の内容を `claude/statusline-powerline.sh` にそのまま反映
- Model 表示への effort レベル併記、Context の最大トークン数・使用率(%)表示、add-dir 表示行(Row4) など、運用中に追加された変更をリポジトリに同期

## Test plan
- [ ] `claude/statusline-powerline.sh` を Claude Code の statusLine 設定に指定し、ステータスラインが4行（Model/Context、Git、CWD、必要に応じてadd-dir）で正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ステータス表示が最大4行に拡張され、より多くの情報を見やすく表示できるようになりました。
  * モデル表示に追加情報が入り、コンテキスト使用量、Git差分、現在の作業ディレクトリ、追加ディレクトリを表示できます。
  * コンテキスト欄で合計トークン数、上限、使用率を確認しやすくなりました。
* **Improvement**
  * Git差分に追加・削除数が追記され、変更量がひと目で分かるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->