### PR TITLE
chore: reasoning effort を medium に設定

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "model": "sonnet",
+  "effortLevel": "medium",
   "permissions": {
     "deny": [
       "Bash(rm*)"


### PR DESCRIPTION
## Summary
- `.claude/settings.json` に `effortLevel: "medium"` を追加
- このリポジトリでClaude Codeを使う際のreasoning effortをチーム共有設定としてmediumに固定する

## Test plan
- [ ] 本リポジトリでClaude Codeを起動し、effortがmediumになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)