### PR TITLE
chore: 不安定挙動対策として settings.json を更新

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -16,7 +16,6 @@
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:azure.status.microsoft)",
       "WebFetch(domain:status.ai.azure.com)",
-      "Read(//Users/m-watanabe/Downloads/**)",
       "Bash(git add*)",
       "Bash(git pull*)",
       "Bash(git commit*)",

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,6 +1,7 @@
 {
   "env": {
-    "CLAUDE_CODE_NO_FLICKER": "1"
+    "CLAUDE_CODE_NO_FLICKER": "1",
+    "CLAUDE_AFK_TIMEOUT_MS": "3600000"
   },
   "permissions": {
     "allow": [
@@ -15,6 +16,7 @@
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:azure.status.microsoft)",
       "WebFetch(domain:status.ai.azure.com)",
+      "Read(//Users/m-watanabe/Downloads/**)",
       "Bash(git add*)",
       "Bash(git pull*)",
       "Bash(git commit*)",
@@ -82,6 +84,9 @@
     "defaultMode": "default"
   },
   "model": "sonnet",
+  "fallbackModel": [
+    "claude-opus-4-7"
+  ],
   "hooks": {
     "Notification": [
       {
@@ -117,8 +122,9 @@
     }
   },
   "language": "Japanese",
-  "effortLevel": "medium",
+  "effortLevel": "high",
   "advisorModel": "opus",
+  "askUserQuestionTimeout": "never",
   "skipWorkflowUsageWarning": true,
   "theme": "auto",
   "autoCompactEnabled": true,


### PR DESCRIPTION
## Summary
- ローカルで実際に使用している `~/.claude/settings.json` の内容を `claude/settings.json` に取り込み
- `fallbackModel` を Opus 4.8 の不安定さを避けて Opus 4.7 に指定
- Plan モードで放置している間に実行が勝手に進んでしまう事象があったため、`CLAUDE_AFK_TIMEOUT_MS` と `askUserQuestionTimeout: never` を設定してこれを止める
- `effortLevel` の `high` 化

## 変更の理由

### fallbackModel を Opus 4.7 に
Opus 4.8 の挙動がおかしかったため、あえて安定している Opus 4.7 をフォールバック先に指定した。

### CLAUDE_AFK_TIMEOUT_MS / askUserQuestionTimeout
Plan モードで確認待ちのまま放置していたら、いつの間にか勝手に実行が進んでしまったことがあった。これを防ぐため、AFK タイムアウトと `askUserQuestionTimeout` を `never` にして待機時に自動で進まないようにした。

## 参考リンク

### fallbackModel
- https://x.com/u1/status/2073463185085182378?s=12&t=p14v_UxrmC_d5grr6qvVvg
- https://blog.serverworks.co.jp/2026/06/08/190000

### CLAUDE_AFK_TIMEOUT_MS / askUserQuestionTimeout
- https://x.com/u1/status/2072570592965132799?s=12&t=p14v_UxrmC_d5grr6qvVvg
- https://claude-code-log.com/reference/settings/claude-afk-timeout-ms
- https://zenn.dev/ytkdm/articles/claude-code-askuserquestion-timeout

## Test plan
- [x] diff で差分内容を確認済み