### PR TITLE
chore: settings.jsonにSessionEnd時の.playwright-mcp削除フックを反映

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -97,6 +97,16 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rm -rf .playwright-mcp 2>/dev/null || true"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## Summary
- ホーム側 (`~/.claude/settings.json`) で先行して追加していた `SessionEnd` フック（`.playwright-mcp` ディレクトリの削除）をリポジトリの `claude/settings.json` に取り込み

## Test plan
- [ ] `claude/settings.json` の内容が実体である `~/.claude/settings.json` と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * セッション終了時に、一時的な `.playwright-mcp` ディレクトリを自動削除するようになりました。
  * セッション終了後に不要な一時ファイルが残りにくくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->