### PR TITLE
フォールバックモデルをOpus 4.7からOpus 5に変更

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -85,7 +85,7 @@
     "additionalDirectories": ["~/.claude/plugins/cache/openai-codex"]
   },
   "model": "claude-fable-5[1m]",
-  "fallbackModel": ["claude-opus-4-7"],
+  "fallbackModel": ["claude-opus-5"],
   "hooks": {
     "Notification": [
       {


### PR DESCRIPTION
## Summary
- `claude/settings.json` の `fallbackModel` を `claude-opus-4-7` から `claude-opus-5` に更新

## Test plan
- [ ] 設定ファイルのJSON構文が正しいことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * フォールバック時に使用されるモデルを、`claude-opus-5` に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->